### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./host/host_ws/src/webgui/javascript
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+# Source: https://github.com/per1234/.github/blob/main/workflow-templates/spell-check.md
+name: Spell Check
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sudo ./start_docker.sh
 A tmux session will appear, the software base is automatically built and executed.
 
 ## Part 2 (the robot part)
-Install the Realsense ROS enviroment and chrony for timesync:
+Install the Realsense ROS environment and chrony for timesync:
 ~~~bash
 sudo apt-get install ros-noetic-realsense2-camera chrony
 ~~~

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <a href="https://107-systems.org/"><img align="right" src="https://raw.githubusercontent.com/107-systems/.github/main/logo/107-systems.png" width="15%"></a>
 :floppy_disk: `l3xz-mapping`
 ============================
+[![Spell Check status](https://github.com/107-systems/l3xz-mapping/actions/workflows/spell-check.yml/badge.svg)](https://github.com/107-systems/l3xz-mapping/actions/workflows/spell-check.yml)
+
 This repository includes the ROS-based explorative mapping stack of L3X-Z for Elrob 2022.
 
 The stack consists of two parts tested under ROS1 Noetic Ninjemys. Part one runs on a base station, does the mapping using RTAB-Map, data logging and comes with a browser frontend. Part two can be deployed to the Raspberry Pi on the robot. It's purpose is to read all the sensor data and transmit it to part one. 

--- a/client/client_ws/src/CMakeLists.txt
+++ b/client/client_ws/src/CMakeLists.txt
@@ -17,7 +17,7 @@ execute_process(COMMAND ${_cmd}
   ERROR_STRIP_TRAILING_WHITESPACE
 )
 if(NOT _res EQUAL 0 AND NOT _res EQUAL 2)
-  # searching fot catkin resulted in an error
+  # searching for catkin resulted in an error
   string(REPLACE ";" " " _cmd_str "${_cmd}")
   message(FATAL_ERROR "Search for 'catkin' in workspace failed (${_cmd_str}): ${_err}")
 endif()

--- a/host/host_ws/src/l3xz_mapping/launch/rtabmap_base.launch
+++ b/host/host_ws/src/l3xz_mapping/launch/rtabmap_base.launch
@@ -357,7 +357,7 @@
       <param name="Mem/InitWMWithAllNodes" type="string" value="$(arg localization)"/>
     </node>
   
-    <!-- Visualisation RTAB-Map -->
+    <!-- Visualization RTAB-Map -->
     <node if="$(arg rtabmapviz)" pkg="rtabmap_ros" type="rtabmapviz" name="rtabmapviz" args="-d $(arg gui_cfg)" output="$(arg output)" launch-prefix="$(arg launch_prefix)">
       <param     if="$(arg stereo)" name="subscribe_depth"  type="bool" value="false"/>
       <param unless="$(arg stereo)" name="subscribe_depth"  type="bool" value="$(arg depth)"/>


### PR DESCRIPTION
On every push, pull request, and periodically, use the codespell-project/actions-codespell action to check for commonly
misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the ignore-words-list field
of ./.codespellrc. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore
list. The ignore list is comma-separated with no spaces.